### PR TITLE
Migrate from USM to `sycl::buffer`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,11 @@ format:
 
 clean:
 	find . -name '*.o' -o -name 'run' -o -name 'a.out' -o -name '*.gch' | xargs rm -f
+
+aot_cpu:
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) -c main.cpp -o main.o $(INCLUDES)
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(INCLUDES) -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Xs "-march=avx2" similarity_transform.cpp utils.cpp main.o
+
+aot_gpu:
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) -c main.cpp -o main.o $(INCLUDES)
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(INCLUDES) -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xs "-device 0x4905" similarity_transform.cpp utils.cpp main.o

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,21 @@ clean:
 
 aot_cpu:
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) -c main.cpp -o main.o $(INCLUDES)
-	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(INCLUDES) -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Xs "-march=avx2" similarity_transform.cpp utils.cpp main.o
+	@if lscpu | grep -q 'avx512'; then \
+		echo "Using avx512"; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(INCLUDES) -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Xs "-march=avx512" similarity_transform.cpp utils.cpp main.o; \
+	elif lscpu | grep -q 'avx2'; then \
+		echo "Using avx2"; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(INCLUDES) -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Xs "-march=avx2" similarity_transform.cpp utils.cpp main.o; \
+	elif lscpu | grep -q 'avx'; then \
+		echo "Using avx"; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(INCLUDES) -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Xs "-march=avx" similarity_transform.cpp utils.cpp main.o; \
+	elif lscpu | grep -q 'sse4.2'; then \
+		echo "Using sse4.2"; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(INCLUDES) -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Xs "-march=sse4.2" similarity_transform.cpp utils.cpp main.o; \
+	else \
+		echo "Can't AOT compile using avx, avx2, avx512 or sse4.2"; \
+	fi
 
 aot_gpu:
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) -c main.cpp -o main.o $(INCLUDES)

--- a/README.md
+++ b/README.md
@@ -50,32 +50,82 @@ make
 
 ### Benchmark Results
 
-I ran parallel implementation of similarity transform algorithm on multiple hardwares, with multiple randomly generated square matrices of various dimensions, while setting maximum iteration count to *1000* and work group size to *32*.
+I ran parallel implementation of similarity transform algorithm on multiple hardwares, with hilbert matrix of various dimensions, while setting maximum iteration count to *1000* and work group size to *32*.
+
+#### On CPU
 
 ```bash
+$ make aot_cpu && ./a.out
+
 running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
 
 Parallel Algorithm using Similarity Transform for finding max eigen value (with vector)
 
-32   x   32                              4 ms
-64   x   64                            200 ms
-128  x  128                            203 ms
-256  x  256                            442 ms
-512  x  512                            755 ms
-1024 x 1024                           1860 ms
+32   x   32                             10 ms                        7 round(s)
+64   x   64                              3 ms                        8 round(s)
+128  x  128                              3 ms                        9 round(s)
+256  x  256                              5 ms                       10 round(s)
+512  x  512                             15 ms                       12 round(s)
+1024 x 1024                             49 ms                       13 round(s)
+2048 x 2048                            186 ms                       14 round(s)
+4096 x 4096                            775 ms                       15 round(s)
+8192 x 8192                           3461 ms                       17 round(s)
 ```
 
 ```bash
+$ make && ./run # JIT compiled kernels
+
 running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
 
 Parallel Algorithm using Similarity Transform for finding max eigen value (with vector)
 
-32   x   32                            150 ms
-64   x   64                            117 ms
-128  x  128                            159 ms
-256  x  256                            182 ms
-512  x  512                            270 ms
-1024 x 1024                            440 ms
+32   x   32                            341 ms                        7 round(s)
+64   x   64                              2 ms                        8 round(s)
+128  x  128                              3 ms                        9 round(s)
+256  x  256                              4 ms                       10 round(s)
+512  x  512                              6 ms                       12 round(s)
+1024 x 1024                             12 ms                       13 round(s)
+2048 x 2048                             34 ms                       14 round(s)
+4096 x 4096                            106 ms                       15 round(s)
+8192 x 8192                            422 ms                       17 round(s)
+```
+
+#### On GPU
+
+```bash
+$ make aot_gpu && ./a.out
+
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+Parallel Algorithm using Similarity Transform for finding max eigen value (with vector)
+
+32   x   32                            120 ms                        7 round(s)
+64   x   64                              4 ms                        8 round(s)
+128  x  128                              4 ms                        9 round(s)
+256  x  256                              6 ms                       10 round(s)
+512  x  512                             13 ms                       12 round(s)
+1024 x 1024                             57 ms                       13 round(s)
+2048 x 2048                            247 ms                       14 round(s)
+4096 x 4096                           1251 ms                       15 round(s)
+8192 x 8192                           7358 ms                       17 round(s)
+```
+
+```bash
+$ make && ./run # JIT compiled kernels
+
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+Parallel Algorithm using Similarity Transform for finding max eigen value (with vector)
+
+32   x   32                            129 ms                        7 round(s)
+64   x   64                              5 ms                        8 round(s)
+128  x  128                              5 ms                        9 round(s)
+256  x  256                              6 ms                       10 round(s)
+512  x  512                             10 ms                       12 round(s)
+1024 x 1024                             29 ms                       13 round(s)
+2048 x 2048                            155 ms                       14 round(s)
+4096 x 4096                            931 ms                       15 round(s)
+8192 x 8192                           5995 ms                       17 round(s)
 ```
 
 ## Test

--- a/include/similarity_transform.hpp
+++ b/include/similarity_transform.hpp
@@ -31,7 +31,8 @@ typedef sycl::accessor<float, 1, sycl::access::mode::read_write,
 
 int64_t sequential_transform(sycl::queue &q, const float *mat,
                              float *const eigen_val, float *const eigen_vec,
-                             const uint dim, const uint wg_size);
+                             const uint dim, const uint wg_size,
+                             uint *const iter_count);
 
 sycl::event sum_across_rows(sycl::queue &q, buffer_2d mat, buffer_1d vec,
                             const uint dim, const uint wg_size,

--- a/include/similarity_transform.hpp
+++ b/include/similarity_transform.hpp
@@ -33,31 +33,27 @@ int64_t sequential_transform(sycl::queue &q, const float *mat,
                              float *const eigen_val, float *const eigen_vec,
                              const uint dim, const uint wg_size);
 
-sycl::event sum_across_rows(sycl::queue &q, const float *mat, float *const vec,
-                            const uint count, const uint wg_size,
+sycl::event sum_across_rows(sycl::queue &q, buffer_2d mat, buffer_1d vec,
+                            const uint dim, const uint wg_size,
                             std::vector<sycl::event> evts);
 
-sycl::event find_max(sycl::queue &q, const float *vec, float *const max,
-                     const uint count, const uint wg_size,
+sycl::event find_max(sycl::queue &q, buffer_1d vec, buffer_1d max,
+                     const uint dim, const uint wg_size,
                      std::vector<sycl::event> evts);
 
-sycl::event compute_eigen_vector(sycl::queue &q, const float *vec,
-                                 const float *max, float *const eigen_vec,
-                                 const uint count, const uint wg_size,
+sycl::event compute_eigen_vector(sycl::queue &q, buffer_1d vec, buffer_1d max,
+                                 buffer_1d eigen_vec, const uint dim,
+                                 const uint wg_size,
                                  std::vector<sycl::event> evts);
 
-sycl::event initialise_eigen_vector(sycl::queue &q, float *const vec,
-                                    const uint count,
+sycl::event initialise_eigen_vector(sycl::queue &q, buffer_1d vec,
+                                    const uint dim,
                                     std::vector<sycl::event> evts);
 
-sycl::event compute_next_matrix(sycl::queue &q, float *const mat,
-                                const float *sum_vec, const uint count,
-                                const uint wg_size,
+sycl::event compute_next_matrix(sycl::queue &q, buffer_2d mat, buffer_1d vec,
+                                const uint dim, const uint wg_size,
                                 std::vector<sycl::event> evts);
 
-// Check for stopping criteria, whether it's good time to
-// stop as result has converged to max eigen value which was being
-// searched for
-sycl::event stop(sycl::queue &q, const float *vec, uint *const ret,
-                 const uint count, const uint wg_size,
+sycl::event stop(sycl::queue &q, buffer_1d vec, sycl::buffer<uint, 1> ret,
+                 const uint dim, const uint wg_size,
                  std::vector<sycl::event> evts);

--- a/include/similarity_transform.hpp
+++ b/include/similarity_transform.hpp
@@ -4,6 +4,31 @@
 inline constexpr float EPS = 1e-3;
 inline constexpr uint MAX_ITR = 1000;
 
+typedef std::chrono::_V2::steady_clock::time_point tp;
+typedef sycl::buffer<float, 1> buffer_1d;
+typedef sycl::buffer<float, 2> buffer_2d;
+typedef sycl::accessor<float, 1, sycl::access::mode::read,
+                       sycl::access::target::global_buffer>
+    global_1d_reader;
+typedef sycl::accessor<float, 2, sycl::access::mode::read,
+                       sycl::access::target::global_buffer>
+    global_2d_reader;
+typedef sycl::accessor<float, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+    global_1d_writer;
+typedef sycl::accessor<float, 2, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+    global_2d_writer;
+typedef sycl::accessor<float, 1, sycl::access::mode::read_write,
+                       sycl::access::target::global_buffer>
+    global_1d_reader_writer;
+typedef sycl::accessor<float, 2, sycl::access::mode::read_write,
+                       sycl::access::target::global_buffer>
+    global_2d_reader_writer;
+typedef sycl::accessor<float, 1, sycl::access::mode::read_write,
+                       sycl::access::target::local>
+    local_1d_reader_writer;
+
 int64_t sequential_transform(sycl::queue &q, const float *mat,
                              float *const eigen_val, float *const eigen_vec,
                              const uint dim, const uint wg_size);

--- a/include/similarity_transform.hpp
+++ b/include/similarity_transform.hpp
@@ -29,7 +29,7 @@ typedef sycl::accessor<float, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
     local_1d_reader_writer;
 
-int64_t sequential_transform(sycl::queue &q, const float *mat,
+int64_t similarity_transform(sycl::queue &q, const float *mat,
                              float *const eigen_val, float *const eigen_vec,
                              const uint dim, const uint wg_size,
                              uint *const iter_count);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -21,3 +21,5 @@ sycl::event stop_criteria_test_fail_data(sycl::queue &q, float *const vec,
                                          std::vector<sycl::event> evts);
 
 void generate_random_positive_matrix(float *const mat, const uint dim);
+
+void generate_hilbert_matrix(float *const mat, const uint dim);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -22,4 +22,4 @@ sycl::event stop_criteria_test_fail_data(sycl::queue &q, float *const vec,
 
 void generate_random_positive_matrix(float *const mat, const uint dim);
 
-void generate_hilbert_matrix(float *const mat, const uint dim);
+void generate_hilbert_matrix(sycl::queue &q, float *const mat, const uint dim);

--- a/main.cpp
+++ b/main.cpp
@@ -23,11 +23,15 @@ int main() {
     float *eigen_vec = (float *)malloc(sizeof(float) * dim * 1);
 
     generate_random_positive_matrix(mat, dim);
-    int64_t tm = sequential_transform(q, mat, eigen_val, eigen_vec, dim, B);
+    uint itr_count = 0;
+    int64_t tm =
+        sequential_transform(q, mat, eigen_val, eigen_vec, dim, B, &itr_count);
 
     std::cout << std::setw(5) << std::left << dim << "x" << std::setw(5)
               << std::right << dim << "\t\t\t" << std::setw(10) << std::right
-              << tm << " ms" << std::endl;
+              << tm << " ms"
+              << "\t\t\t" << std::setw(6) << std::right << itr_count
+              << std::endl;
 
     std::free(mat);
     std::free(eigen_val);

--- a/main.cpp
+++ b/main.cpp
@@ -25,7 +25,7 @@ int main() {
     generate_random_positive_matrix(mat, dim);
     uint itr_count = 0;
     int64_t tm =
-        sequential_transform(q, mat, eigen_val, eigen_vec, dim, B, &itr_count);
+        similarity_transform(q, mat, eigen_val, eigen_vec, dim, B, &itr_count);
 
     std::cout << std::setw(5) << std::left << dim << "x" << std::setw(5)
               << std::right << dim << "\t\t\t" << std::setw(10) << std::right

--- a/main.cpp
+++ b/main.cpp
@@ -22,7 +22,7 @@ int main() {
     float *eigen_val = (float *)malloc(sizeof(float) * 1);
     float *eigen_vec = (float *)malloc(sizeof(float) * dim * 1);
 
-    generate_hilbert_matrix(mat, dim);
+    generate_hilbert_matrix(q, mat, dim);
     uint itr_count = 0;
     int64_t tm =
         similarity_transform(q, mat, eigen_val, eigen_vec, dim, B, &itr_count);

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 
 using namespace sycl;
 
-const uint N = 1 << 10;
+const uint N = 1 << 13;
 const uint B = 1 << 5;
 
 int main() {
@@ -22,7 +22,7 @@ int main() {
     float *eigen_val = (float *)malloc(sizeof(float) * 1);
     float *eigen_vec = (float *)malloc(sizeof(float) * dim * 1);
 
-    generate_random_positive_matrix(mat, dim);
+    generate_hilbert_matrix(mat, dim);
     uint itr_count = 0;
     int64_t tm =
         similarity_transform(q, mat, eigen_val, eigen_vec, dim, B, &itr_count);
@@ -31,7 +31,7 @@ int main() {
               << std::right << dim << "\t\t\t" << std::setw(10) << std::right
               << tm << " ms"
               << "\t\t\t" << std::setw(6) << std::right << itr_count
-              << std::endl;
+              << " round(s)" << std::endl;
 
     std::free(mat);
     std::free(eigen_val);

--- a/similarity_transform.cpp
+++ b/similarity_transform.cpp
@@ -1,7 +1,7 @@
 #include "similarity_transform.hpp"
 #include <chrono>
 
-int64_t sequential_transform(sycl::queue &q, const float *mat,
+int64_t similarity_transform(sycl::queue &q, const float *mat,
                              float *const eigen_val, float *const eigen_vec,
                              const uint dim, const uint wg_size,
                              uint *const iter_count) {

--- a/similarity_transform.cpp
+++ b/similarity_transform.cpp
@@ -3,7 +3,8 @@
 
 int64_t sequential_transform(sycl::queue &q, const float *mat,
                              float *const eigen_val, float *const eigen_vec,
-                             const uint dim, const uint wg_size) {
+                             const uint dim, const uint wg_size,
+                             uint *const iter_count) {
   float *mat_ = (float *)malloc(sizeof(float) * dim * dim);
   float *sum_vec = (float *)malloc(sizeof(float) * dim);
   float *max_elm = (float *)malloc(sizeof(float) * 1);
@@ -23,7 +24,8 @@ int64_t sequential_transform(sycl::queue &q, const float *mat,
 
   tp start = std::chrono::steady_clock::now();
 
-  for (uint i = 0; i < MAX_ITR; i++) {
+  uint i = 0;
+  for (; i < MAX_ITR; i++) {
     sum_across_rows(q, b_mat, b_sum_vec, dim, wg_size, {});
     find_max(q, b_sum_vec, b_max_elm, dim, wg_size, {});
     compute_eigen_vector(q, b_sum_vec, b_max_elm, b_eigen_vec, dim, wg_size,
@@ -38,6 +40,7 @@ int64_t sequential_transform(sycl::queue &q, const float *mat,
 
     compute_next_matrix(q, b_mat, b_sum_vec, dim, wg_size, {});
   }
+  *iter_count = i;
 
   q.wait();
   tp end = std::chrono::steady_clock::now();

--- a/similarity_transform.cpp
+++ b/similarity_transform.cpp
@@ -190,9 +190,11 @@ sycl::event compute_eigen_vector(sycl::queue &q, buffer_1d vec, buffer_1d max,
     h.parallel_for<class kernelComputeEigenVector>(
         sycl::nd_range<1>{sycl::range<1>{dim}, sycl::range<1>{wg_size}}, [=
     ](sycl::nd_item<1> it) [[intel::reqd_sub_group_size(32)]] {
-          const size_t r = it.get_global_id(0);
+          sycl::ext::oneapi::sub_group sg = it.get_sub_group();
 
-          acc_eigen_vec[r] *= (acc_vec[r] / acc_max[0]);
+          const size_t r = it.get_global_id(0);
+          acc_eigen_vec[r] *=
+              (acc_vec[r] / sg.broadcast(acc_max[0], it.get_local_id(0)));
         });
   });
 

--- a/similarity_transform.cpp
+++ b/similarity_transform.cpp
@@ -194,7 +194,7 @@ sycl::event compute_eigen_vector(sycl::queue &q, buffer_1d vec, buffer_1d max,
 
           const size_t r = it.get_global_id(0);
           acc_eigen_vec[r] *=
-              (acc_vec[r] / sg.broadcast(acc_max[0], it.get_local_id(0)));
+              (acc_vec[r] / sycl::group_broadcast(sg, acc_max[0]));
         });
   });
 

--- a/similarity_transform.cpp
+++ b/similarity_transform.cpp
@@ -4,61 +4,57 @@
 int64_t sequential_transform(sycl::queue &q, const float *mat,
                              float *const eigen_val, float *const eigen_vec,
                              const uint dim, const uint wg_size) {
-  float *_mat = (float *)sycl::malloc_device(sizeof(float) * dim * dim, q);
-  float *tmp_vec = (float *)sycl::malloc_device(sizeof(float) * dim, q);
-  float *_eigen_vec = (float *)sycl::malloc_device(sizeof(float) * dim, q);
-  float *max_elm = (float *)sycl::malloc_shared(sizeof(float) * 1, q);
-  uint *ret = (uint *)sycl::malloc_shared(sizeof(uint) * 1, q);
+  float *mat_ = (float *)malloc(sizeof(float) * dim * dim);
+  float *sum_vec = (float *)malloc(sizeof(float) * dim);
+  float *max_elm = (float *)malloc(sizeof(float) * 1);
+  uint *ret = (uint *)malloc(sizeof(uint) * 1);
 
-  auto evt_0 = q.memcpy(_mat, mat, sizeof(float) * dim * dim);
-  auto evt_1 = initialise_eigen_vector(q, _eigen_vec, dim, {});
+  memcpy(mat_, mat, sizeof(float) * dim * dim);
+
+  buffer_2d b_mat{mat_, sycl::range<2>{dim, dim}};
+  buffer_1d b_eigen_vec{eigen_vec, sycl::range<1>{dim}};
+  buffer_1d b_eigen_val{eigen_val, sycl::range<1>{1}};
+
+  buffer_1d b_sum_vec{sum_vec, sycl::range<1>{dim}};
+  buffer_1d b_max_elm{max_elm, sycl::range<1>{1}};
+  sycl::buffer<uint, 1> b_ret{ret, sycl::range<1>{1}};
+
+  initialise_eigen_vector(q, b_eigen_vec, dim, {});
 
   tp start = std::chrono::steady_clock::now();
 
-  sycl::event evt;
   for (uint i = 0; i < MAX_ITR; i++) {
-    sycl::event evt_2;
-    if (i == 0) {
-      evt_2 = sum_across_rows(q, _mat, tmp_vec, dim, wg_size, {evt_0});
-    } else {
-      evt_2 = sum_across_rows(q, _mat, tmp_vec, dim, wg_size, {evt});
+    sum_across_rows(q, b_mat, b_sum_vec, dim, wg_size, {});
+    find_max(q, b_sum_vec, b_max_elm, dim, wg_size, {});
+    compute_eigen_vector(q, b_sum_vec, b_max_elm, b_eigen_vec, dim, wg_size,
+                         {});
+    stop(q, b_sum_vec, b_ret, dim, wg_size, {});
+    {
+      sycl::host_accessor<uint, 1, sycl::access_mode::read> h_ret{b_ret};
+      if (h_ret[0] == 1) {
+        break;
+      }
     }
 
-    auto evt_3 = find_max(q, tmp_vec, max_elm, dim, wg_size, {evt_2});
-
-    sycl::event evt_4;
-    if (i == 0) {
-      evt_4 = compute_eigen_vector(q, tmp_vec, max_elm, _eigen_vec, dim,
-                                   wg_size, {evt_1, evt_3});
-    } else {
-      evt_4 = compute_eigen_vector(q, tmp_vec, max_elm, _eigen_vec, dim,
-                                   wg_size, {evt_3});
-    }
-
-    auto evt_5 = stop(q, tmp_vec, ret, dim, wg_size, {evt_3});
-    evt_5.wait();
-
-    if (*ret == 1) {
-      evt = evt_4;
-      break;
-    }
-
-    evt = compute_next_matrix(q, _mat, tmp_vec, dim, wg_size, {});
+    compute_next_matrix(q, b_mat, b_sum_vec, dim, wg_size, {});
   }
 
+  q.wait();
   tp end = std::chrono::steady_clock::now();
 
-  q.memcpy(eigen_val, tmp_vec, sizeof(float) * 1);
-  evt.wait();
+  q.submit([&](sycl::handler &h) {
+    global_1d_reader acc_sum_vec{b_sum_vec, h, sycl::range<1>{1}};
+    global_1d_writer acc_eigen_val{b_eigen_val, h};
 
-  evt = q.memcpy(eigen_vec, _eigen_vec, sizeof(float) * dim);
-  sycl::free(tmp_vec, q);
-  sycl::free(_mat, q);
-  sycl::free(max_elm, q);
-  sycl::free(ret, q);
-  evt.wait();
+    h.copy(acc_sum_vec, acc_eigen_val);
+  });
+  q.wait();
 
-  sycl::free(_eigen_vec, q);
+  std::free(mat_);
+  std::free(sum_vec);
+  std::free(max_elm);
+  std::free(ret);
+
   return std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
       .count();
 }
@@ -139,76 +135,6 @@ sycl::event sum_across_rows(sycl::queue &q, buffer_2d mat, buffer_1d vec,
   return evt;
 }
 
-sycl::event sum_across_rows(sycl::queue &q, const float *mat, float *const vec,
-                            const uint count, const uint wg_size,
-                            std::vector<sycl::event> evts) {
-  auto evt_0 = q.memset(vec, 0, sizeof(float) * count);
-  evts.push_back(evt_0);
-
-  auto evt_1 = q.submit([&](sycl::handler &h) {
-    h.depends_on(evts);
-
-    if (q.get_device().is_gpu()) {
-      sycl::accessor<float, 1, sycl::access::mode::read_write,
-                     sycl::access::target::local>
-          lds(sycl::range<1>{1}, h);
-
-      h.parallel_for<class kernelSumAcrossRowsGPU>(
-          sycl::nd_range<2>{sycl::range<2>{count, count},
-                            sycl::range<2>{1, wg_size}},
-          [=](sycl::nd_item<2> it) [[intel::reqd_sub_group_size(16)]] {
-            const size_t r = it.get_global_id(0);
-            const size_t c = it.get_global_id(1);
-
-            float val = *(mat + r * count + c);
-
-            const size_t loc_id = it.get_local_linear_id();
-            if (loc_id == 0) {
-              lds[0] = 0;
-            }
-
-            it.barrier(sycl::access::fence_space::local_space);
-
-            sycl::ext::oneapi::atomic_ref<
-                float, sycl::ext::oneapi::memory_order::relaxed,
-                sycl::ext::oneapi::memory_scope::work_group,
-                sycl::access::address_space::local_space>
-                ref(lds[0]);
-            ref.fetch_add(val);
-
-            it.barrier(sycl::access::fence_space::local_space);
-
-            if (loc_id == 0) {
-              sycl::ext::oneapi::atomic_ref<
-                  float, sycl::ext::oneapi::memory_order::relaxed,
-                  sycl::ext::oneapi::memory_scope::device,
-                  sycl::access::address_space::global_space>
-                  ref(*(vec + r));
-              ref.fetch_add(lds[0]);
-            }
-          });
-    } else {
-      h.parallel_for<class kernelSumAcrossRowsOthers>(
-          sycl::nd_range<2>{sycl::range<2>{count, count},
-                            sycl::range<2>{1, wg_size}},
-          [=](sycl::nd_item<2> it) [[intel::reqd_sub_group_size(16)]] {
-            const size_t r = it.get_global_id(0);
-            const size_t c = it.get_global_id(1);
-
-            float val = *(mat + r * count + c);
-            sycl::ext::oneapi::atomic_ref<
-                float, sycl::ext::oneapi::memory_order::relaxed,
-                sycl::ext::oneapi::memory_scope::device,
-                sycl::access::address_space::global_space>
-                ref(*(vec + r));
-            ref.fetch_add(val);
-          });
-    }
-  });
-
-  return evt_1;
-}
-
 sycl::event find_max(sycl::queue &q, buffer_1d vec, buffer_1d max,
                      const uint dim, const uint wg_size,
                      std::vector<sycl::event> evts) {
@@ -245,31 +171,6 @@ sycl::event find_max(sycl::queue &q, buffer_1d vec, buffer_1d max,
   return evt;
 }
 
-sycl::event find_max(sycl::queue &q, const float *vec, float *const max,
-                     const uint count, const uint wg_size,
-                     std::vector<sycl::event> evts) {
-  auto evt_0 = q.memset(max, 0, sizeof(float));
-  evts.push_back(evt_0);
-
-  auto evt_1 = q.submit([&](sycl::handler &h) {
-    h.depends_on(evts);
-    h.parallel_for<class kernelMaxInVector>(
-        sycl::nd_range<1>{sycl::range<1>{count}, sycl::range<1>{wg_size}},
-        [=](sycl::nd_item<1> it) {
-          const size_t r = it.get_global_id(0);
-
-          sycl::ext::oneapi::atomic_ref<
-              float, sycl::ext::oneapi::memory_order::relaxed,
-              sycl::ext::oneapi::memory_scope::device,
-              sycl::access::address_space::global_space>
-              ref(*max);
-          ref.fetch_max(*(vec + r));
-        });
-  });
-
-  return evt_1;
-}
-
 sycl::event compute_eigen_vector(sycl::queue &q, buffer_1d vec, buffer_1d max,
                                  buffer_1d eigen_vec, const uint dim,
                                  const uint wg_size,
@@ -295,24 +196,6 @@ sycl::event compute_eigen_vector(sycl::queue &q, buffer_1d vec, buffer_1d max,
   return evt;
 }
 
-sycl::event compute_eigen_vector(sycl::queue &q, const float *vec,
-                                 const float *max, float *const eigen_vec,
-                                 const uint count, const uint wg_size,
-                                 std::vector<sycl::event> evts) {
-  auto evt = q.submit([&](sycl::handler &h) {
-    h.depends_on(evts);
-    h.parallel_for<class kernelComputeEigenVector>(
-        sycl::nd_range<1>{sycl::range<1>{count}, sycl::range<1>{wg_size}},
-        [=](sycl::nd_item<1> it) {
-          const size_t r = it.get_global_id(0);
-
-          *(eigen_vec + r) *= (*(vec + r) / *max);
-        });
-  });
-
-  return evt;
-}
-
 sycl::event initialise_eigen_vector(sycl::queue &q, buffer_1d vec,
                                     const uint dim,
                                     std::vector<sycl::event> evts) {
@@ -324,17 +207,6 @@ sycl::event initialise_eigen_vector(sycl::queue &q, buffer_1d vec,
     }
 
     h.fill(acc_vec, 1.f);
-  });
-
-  return evt;
-}
-
-sycl::event initialise_eigen_vector(sycl::queue &q, float *const vec,
-                                    const uint count,
-                                    std::vector<sycl::event> evts) {
-  auto evt = q.submit([&](sycl::handler &h) {
-    h.depends_on(evts);
-    h.fill(vec, 1.f, count);
   });
 
   return evt;
@@ -367,29 +239,6 @@ sycl::event compute_next_matrix(sycl::queue &q, buffer_2d mat, buffer_1d vec,
   return evt;
 }
 
-sycl::event compute_next_matrix(sycl::queue &q, float *const mat,
-                                const float *sum_vec, const uint count,
-                                const uint wg_size,
-                                std::vector<sycl::event> evts) {
-  auto evt = q.submit([&](sycl::handler &h) {
-    h.depends_on(evts);
-    h.parallel_for<class kernelSimilarityTransform>(
-        sycl::nd_range<2>{sycl::range<2>{count, count},
-                          sycl::range<2>{1, wg_size}},
-        [=](sycl::nd_item<2> it) {
-          const size_t r = it.get_global_id(0);
-          const size_t c = it.get_global_id(1);
-
-          float v0 = *(sum_vec + r);
-          float v1 = r == c ? v0 : *(sum_vec + c);
-
-          *(mat + r * count + c) *= (1.f / v0) * v1;
-        });
-  });
-
-  return evt;
-}
-
 sycl::event stop(sycl::queue &q, buffer_1d vec, sycl::buffer<uint, 1> ret,
                  const uint dim, const uint wg_size,
                  std::vector<sycl::event> evts) {
@@ -404,7 +253,7 @@ sycl::event stop(sycl::queue &q, buffer_1d vec, sycl::buffer<uint, 1> ret,
       h.depends_on(evts);
     }
 
-    h.single_task([=]() { acc_ret[0] = 1; });
+    h.fill(acc_ret, 1U);
   });
 
   auto evt = q.submit([&](sycl::handler &h) {
@@ -435,41 +284,4 @@ sycl::event stop(sycl::queue &q, buffer_1d vec, sycl::buffer<uint, 1> ret,
   });
 
   return evt;
-}
-
-sycl::event stop(sycl::queue &q, const float *vec, uint *const ret,
-                 const uint count, const uint wg_size,
-                 std::vector<sycl::event> evts) {
-  auto evt_0 = q.single_task([=]() {
-    // == 1, denotes should stop !
-    *ret = 1;
-  });
-  evts.push_back(evt_0);
-
-  auto evt_1 = q.submit([&](sycl::handler &h) {
-    h.depends_on(evts);
-    h.parallel_for<class kernelStopCriteria>(
-        sycl::nd_range<1>{sycl::range<1>{count}, sycl::range<1>{wg_size}},
-        [=](sycl::nd_item<1> it) {
-          sycl::ext::oneapi::sub_group sg = it.get_sub_group();
-          const size_t r = it.get_global_id(0);
-          if (r == 0) {
-            return;
-          }
-
-          float diff = sycl::abs(*(vec + r) - *(vec + (r - 1)));
-          bool res = sycl::all_of_group(sg, diff < EPS);
-
-          if (sycl::ext::oneapi::leader(sg)) {
-            sycl::ext::oneapi::atomic_ref<
-                uint, sycl::ext::oneapi::memory_order::relaxed,
-                sycl::ext::oneapi::memory_scope::device,
-                sycl::access::address_space::global_space>
-                ref{*ret};
-            ref.fetch_min(res ? 1 : 0);
-          }
-        });
-  });
-
-  return evt_1;
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -13,48 +13,71 @@ int main() {
   std::cout << "running on " << d.get_info<info::device::name>() << "\n"
             << std::endl;
 
-  float *mat = (float *)malloc_shared(sizeof(float) * N * N, q);
-  float *vec = (float *)malloc_shared(sizeof(float) * N * 1, q);
-  float *eigen_vec = (float *)malloc_shared(sizeof(float) * N * 1, q);
+  float *mat = (float *)malloc(sizeof(float) * N * N);
+  float *vec = (float *)malloc(sizeof(float) * N * 1);
+  float *eigen_vec = (float *)malloc(sizeof(float) * N * 1);
 
   identity_matrix(q, mat, N, B, {}).wait();
-  sum_across_rows(q, mat, vec, N, B, {}).wait();
+  {
+    buffer_2d buf_mat{mat, range<2>{N, N}};
+    buffer_1d buf_vec{vec, range<1>{N}};
 
+    sum_across_rows(q, buf_mat, buf_vec, N, B, {}).wait();
+  }
   check(vec, N);
   std::cout << "sum across row works !" << std::endl;
 
-  float *max = (float *)malloc_shared(sizeof(float) * 1, q);
+  float *max = (float *)malloc(sizeof(float) * 1);
   generate_vector(q, vec, N, B, {}).wait();
-  find_max(q, vec, max, N, B, {}).wait();
+  {
+    buffer_1d buf_vec{vec, sycl::range<1>{N}};
+    buffer_1d buf_max{max, sycl::range<1>{1}};
 
+    find_max(q, buf_vec, buf_max, N, B, {}).wait();
+  }
   assert(*max == N);
   std::cout << "max from vector works !" << std::endl;
 
-  initialise_eigen_vector(q, eigen_vec, N, {}).wait();
-  compute_eigen_vector(q, vec, max, eigen_vec, N, B, {}).wait();
+  {
+    buffer_1d buf_vec{vec, sycl::range<1>{N}};
+    buffer_1d buf_eigen_vec{eigen_vec, sycl::range<1>{N}};
+    buffer_1d buf_max{max, sycl::range<1>{1}};
+
+    initialise_eigen_vector(q, buf_eigen_vec, N, {}).wait();
+    compute_eigen_vector(q, buf_vec, buf_max, buf_eigen_vec, N, B, {}).wait();
+  }
 
   float max_dev = check_eigen_vector(vec, eigen_vec, *max, N);
   std::cout << "maximum deviation in computing eigen vector " << max_dev
             << std::endl;
 
-  uint *ret = (uint *)malloc_shared(sizeof(uint) * 1, q);
+  uint *ret = (uint *)malloc(sizeof(uint) * 1);
   stop_criteria_test_success_data(q, vec, N, B, {}).wait();
+  {
+    buffer_1d buf_vec{vec, sycl::range<1>{N}};
+    buffer<uint, 1> buf_ret{ret, range<1>{1}};
 
-  stop(q, vec, ret, N, B, {}).wait();
+    stop(q, buf_vec, buf_ret, N, B, {}).wait();
+  }
   std::cout << "stopping criteria test result [success]: " << *ret << std::endl;
 
   stop_criteria_test_fail_data(q, vec, N, B, {}).wait();
+  {
+    buffer_1d buf_vec{vec, sycl::range<1>{N}};
+    buffer<uint, 1> buf_ret{ret, range<1>{1}};
 
-  stop(q, vec, ret, N, B, {}).wait();
+    stop(q, buf_vec, buf_ret, N, B, {}).wait();
+  }
   std::cout << "stopping criteria test result [fail]: " << *ret << std::endl;
 
-  sycl::free(mat, q);
-  sycl::free(vec, q);
-  sycl::free(eigen_vec, q);
+  std::free(mat);
+  std::free(vec);
+  std::free(eigen_vec);
 
   mat = (float *)malloc(sizeof(float) * 3 * 3);
   eigen_vec = (float *)malloc(sizeof(float) * 3 * 1);
   float *eigen_val = (float *)malloc(sizeof(float) * 1);
+  uint iter_count = 0;
 
   *(mat + 0 * 3 + 0) = 1;
   *(mat + 0 * 3 + 1) = 1;
@@ -68,13 +91,14 @@ int main() {
   *(mat + 2 * 3 + 1) = 3;
   *(mat + 2 * 3 + 2) = 5;
 
-  sequential_transform(q, mat, eigen_val, eigen_vec, 3, 3);
+  sequential_transform(q, mat, eigen_val, eigen_vec, 3, 3, &iter_count);
 
   assert(abs(*eigen_val - 7.53114) < EPS);
   assert(abs(*(eigen_vec + 0) - 0.394074) < EPS);
   assert(abs(*(eigen_vec + 1) - 0.578844) < EPS);
   assert(abs(*(eigen_vec + 2) - 0.997451) < EPS);
-  std::cout << "sequential transform worked !" << std::endl;
+  std::cout << "sequential transform worked !\t\t[ " << iter_count << " iterations ]"
+            << std::endl;
 
   std::free(mat);
   std::free(eigen_val);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -91,7 +91,7 @@ int main() {
   *(mat + 2 * 3 + 1) = 3;
   *(mat + 2 * 3 + 2) = 5;
 
-  sequential_transform(q, mat, eigen_val, eigen_vec, 3, 3, &iter_count);
+  similarity_transform(q, mat, eigen_val, eigen_vec, 3, 3, &iter_count);
 
   assert(abs(*eigen_val - 7.53114) < EPS);
   assert(abs(*(eigen_vec + 0) - 0.394074) < EPS);

--- a/utils.cpp
+++ b/utils.cpp
@@ -58,7 +58,7 @@ float check_eigen_vector(const float *vec, const float *eigen_vec,
 sycl::event stop_criteria_test_success_data(sycl::queue &q, float *const vec,
                                             const uint dim, const uint wg_size,
                                             std::vector<sycl::event> evts) {
-  const float EPS = 1e-4;
+  const float EPS = 1e-4f;
   memset(vec, 0, sizeof(float) * dim);
   buffer_1d buf_vec{vec, sycl::range<1>{dim}};
 
@@ -70,7 +70,7 @@ sycl::event stop_criteria_test_success_data(sycl::queue &q, float *const vec,
         sycl::nd_range<1>{sycl::range<1>{dim}, sycl::range<1>{wg_size}},
         [=](sycl::nd_item<1> it) {
           const size_t r = it.get_global_id(0);
-          acc_vec[r] = (r + 1) * EPS;
+          acc_vec[r] = 1.f + EPS;
         });
   });
   return evt_1;
@@ -79,7 +79,7 @@ sycl::event stop_criteria_test_success_data(sycl::queue &q, float *const vec,
 sycl::event stop_criteria_test_fail_data(sycl::queue &q, float *const vec,
                                          const uint dim, const uint wg_size,
                                          std::vector<sycl::event> evts) {
-  const float EPS = 1e-4;
+  const float EPS = 1e-4f;
   memset(vec, 0, sizeof(float) * dim);
   buffer_1d buf_vec{vec, sycl::range<1>{dim}};
 
@@ -91,11 +91,7 @@ sycl::event stop_criteria_test_fail_data(sycl::queue &q, float *const vec,
         sycl::nd_range<1>{sycl::range<1>{dim}, sycl::range<1>{wg_size}},
         [=](sycl::nd_item<1> it) {
           const size_t r = it.get_global_id(0);
-          if (r == wg_size - 1) {
-            acc_vec[r] = r + 1;
-          } else {
-            acc_vec[r] = (r + 1) * EPS;
-          }
+          acc_vec[r] = (float)(r + 1) * EPS;
         });
   });
   return evt_1;

--- a/utils.cpp
+++ b/utils.cpp
@@ -121,7 +121,7 @@ void generate_hilbert_matrix(sycl::queue &q, float *const mat, const uint dim) {
           const size_t r = it.get_global_id(0);
           const size_t c = it.get_global_id(1);
 
-          acc_mat[r][c] = (double)1 / (double)(r + c + 1);
+          acc_mat[r][c] = 1.f / (float)(r + c + 1);
         });
   });
   evt.wait();

--- a/utils.cpp
+++ b/utils.cpp
@@ -100,7 +100,7 @@ void generate_random_positive_matrix(float *const mat, const uint dim) {
 
   for (uint i = 0; i < dim; i++) {
     for (uint j = 0; j < dim; j++) {
-      *(mat + i * dim + j) = dis(gen) * (float)(i + j + 1);
+      *(mat + i * dim + j) = dis(gen);
     }
   }
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -112,3 +112,11 @@ void generate_random_positive_matrix(float *const mat, const uint dim) {
     }
   }
 }
+
+void generate_hilbert_matrix(float *const mat, const uint dim) {
+  for (uint i = 0; i < dim; i++) {
+    for (uint j = 0; j < dim; j++) {
+      *(mat + i * dim + j) = (double)1 / (double)(i + j + 1);
+    }
+  }
+}


### PR DESCRIPTION
Implementing based on `sycl::buffer` to test performance compared to existing USM based implementation. 